### PR TITLE
OpenStack and CloudStack: Allow to choose the kind of contextualization

### DIFF
--- a/cloudstack/jar/src/main/java/com/sixsq/slipstream/connector/cloudstack/CloudStackSystemConfigurationParametersFactory.java
+++ b/cloudstack/jar/src/main/java/com/sixsq/slipstream/connector/cloudstack/CloudStackSystemConfigurationParametersFactory.java
@@ -15,6 +15,7 @@ public class CloudStackSystemConfigurationParametersFactory extends
 	protected void initReferenceParameters() throws ValidationException {
 
 		super.initReferenceParameters();
+		super.putMandatoryContextualizationType();
 
 		putMandatoryEndpoint();
 

--- a/openstack/jar/src/main/java/com/sixsq/slipstream/connector/openstack/OpenStackSystemConfigurationParametersFactory.java
+++ b/openstack/jar/src/main/java/com/sixsq/slipstream/connector/openstack/OpenStackSystemConfigurationParametersFactory.java
@@ -35,6 +35,7 @@ public class OpenStackSystemConfigurationParametersFactory extends
 	protected void initReferenceParameters() throws ValidationException {
 		super.initReferenceParameters();
 		super.putMandatoryEndpoint();
+		super.putMandatoryContextualizationType();
 
 		putMandatoryParameter(constructKey(OpenStackUserParametersFactory.ORCHESTRATOR_INSTANCE_TYPE_PARAMETER_NAME),
 				"OpenStack Flavor for the orchestrator. " +


### PR DESCRIPTION
Allow SlipStream administrators to choose the kind of contextualization to use for Linux and Windows machines for CloudStack an OpenStack.

Connected to slipstream/SlipStream#69

The following PR have to be merged before:
- slipstream/SlipStreamServer#373
- slipstream/SlipStreamClient#119