### PR TITLE
Wrong client python module name and connector download URL

### DIFF
--- a/cloudstack/java/jar/src/main/java/com/sixsq/slipstream/connector/cloudstack/CloudStackAdvancedZoneConnector.java
+++ b/cloudstack/java/jar/src/main/java/com/sixsq/slipstream/connector/cloudstack/CloudStackAdvancedZoneConnector.java
@@ -34,7 +34,7 @@ public class CloudStackAdvancedZoneConnector extends CloudStackConnector {
 
 	public static final String ZONE_TYPE = "Advanced";
 	public static final String CLOUD_SERVICE_NAME = "cloudstackadvancedzone";
-	public static final String CLOUDCONNECTOR_PYTHON_MODULENAME = "slipstream.cloudconnectors.cloudstack.CloudStackAdvancedZoneClientCloud";
+	public static final String CLOUDCONNECTOR_PYTHON_MODULENAME = "slipstream_cloudstack.CloudStackAdvancedZoneClientCloud";
 
 	public CloudStackAdvancedZoneConnector() {
 		this(CLOUD_SERVICE_NAME);

--- a/cloudstack/java/jar/src/main/java/com/sixsq/slipstream/connector/cloudstack/CloudStackConnector.java
+++ b/cloudstack/java/jar/src/main/java/com/sixsq/slipstream/connector/cloudstack/CloudStackConnector.java
@@ -42,7 +42,7 @@ public class CloudStackConnector extends CliConnectorBase {
 
 	public static final String ZONE_TYPE = "Basic";
 	public static final String CLOUD_SERVICE_NAME = "cloudstack";
-	public static final String CLOUDCONNECTOR_PYTHON_MODULENAME = "slipstream.cloudconnectors.cloudstack.CloudStackClientCloud";
+	public static final String CLOUDCONNECTOR_PYTHON_MODULENAME = "slipstream_cloudstack.CloudStackClientCloud";
 
 	public CloudStackConnector() {
 		this(CLOUD_SERVICE_NAME);
@@ -67,12 +67,6 @@ public class CloudStackConnector extends CliConnectorBase {
 	@Override
 	protected String getCloudConnectorPythonModule() {
 		return CLOUDCONNECTOR_PYTHON_MODULENAME;
-	}
-
-	@Override
-	protected String getCloudConnectorBundleUrl(User user) throws ValidationException {
-		Configuration configuration = Configuration.getInstance();
-		return configuration.getRequiredProperty("cloud.connector.library.libcloud.url");
 	}
 
 	@Override

--- a/openstack/java/jar/src/main/java/com/sixsq/slipstream/connector/openstack/OpenStackConnector.java
+++ b/openstack/java/jar/src/main/java/com/sixsq/slipstream/connector/openstack/OpenStackConnector.java
@@ -40,7 +40,7 @@ import com.sixsq.slipstream.persistence.UserParameter;
 public class OpenStackConnector extends CliConnectorBase {
 
 	public static final String CLOUD_SERVICE_NAME = "openstack";
-	public static final String CLOUDCONNECTOR_PYTHON_MODULENAME = "slipstream.cloudconnectors.openstack.OpenStackClientCloud";
+	public static final String CLOUDCONNECTOR_PYTHON_MODULENAME = "slipstream_openstack.OpenStackClientCloud";
 
 	public OpenStackConnector() {
 		this(CLOUD_SERVICE_NAME);
@@ -173,12 +173,6 @@ public class OpenStackConnector extends CliConnectorBase {
 	@Override
 	public Credentials getCredentials(User user) {
 		return new OpenStackCredentials(user, getConnectorInstanceName());
-	}
-
-	@Override
-	protected String getCloudConnectorBundleUrl(User user) throws ValidationException {
-		Configuration configuration = Configuration.getInstance();
-		return configuration.getRequiredProperty("cloud.connector.library.libcloud.url");
 	}
 
 	protected java.util.Map<String,String> getConnectorSpecificEnvironment(Run run, User user)


### PR DESCRIPTION
Connected to #47 

This is a bug that slipped into v2.15 candidate during the migration of the OpenStack and CloudStack connectors from `SlipStreamClient` project to the respective modules of SlipStreamConnectors project.

Now the fix was validated on a live instance with nuv.la prod db.
