### PR TITLE
Implemented the new method _create_allow_all_security_group on CloudStack and OpenStack

### DIFF
--- a/cloudstack/java/jar/src/main/java/com/sixsq/slipstream/connector/cloudstack/CloudStackConnector.java
+++ b/cloudstack/java/jar/src/main/java/com/sixsq/slipstream/connector/cloudstack/CloudStackConnector.java
@@ -83,23 +83,14 @@ public class CloudStackConnector extends CliConnectorBase {
 			throws ConfigurationException, ValidationException {
 		Map<String, String> launchParams = new HashMap<String, String>();
 		launchParams.put("instance-type", getInstanceType(run, user));
-		String securityGroups = getSecurityGroups(run);
-		if (securityGroups != null && !securityGroups.isEmpty()) {
-			launchParams.put("security-groups", securityGroups);
-		}
 		launchParams.put("zone-type", getZoneType());
 		launchParams.put("networks", getNetworks(run, user));
+		putLaunchParamSecurityGroups(launchParams, run, user);
 		return launchParams;
 	}
 
 	protected String getNetworks(Run run, User user) throws ValidationException{
 		return "";
-	}
-
-	protected String getSecurityGroups(Run run) throws ValidationException{
-		return (isInOrchestrationContext(run)) ? ""
-				: getParameterValue(CloudStackImageParametersFactory.SECURITY_GROUPS,
-						ImageModule.load(run.getModuleResourceUrl()));
 	}
 
 	protected String getInstanceType(Run run, User user) throws ValidationException {
@@ -109,16 +100,16 @@ public class CloudStackConnector extends CliConnectorBase {
 	}
 
 	protected String getZone(User user) throws ValidationException {
-		return user.getParameter(constructKey(
-				CloudStackUserParametersFactory.ZONE_PARAMETER_NAME))
-				.getValue();
+		return user.getParameter(constructKey(CloudStackUserParametersFactory.ZONE_PARAMETER_NAME)).getValue();
 	}
 
+	@Override
 	protected void validateDescribe(User user) throws ValidationException {
 		validateCredentials(user);
 		validateBaseParameters(user);
 	}
 
+	@Override
 	protected void validateTerminate(Run run, User user) throws ValidationException {
 		validateCredentials(user);
 		validateBaseParameters(user);
@@ -143,6 +134,7 @@ public class CloudStackConnector extends CliConnectorBase {
 		}
 	}
 
+	@Override
 	protected void validateLaunch(Run run, User user) throws ValidationException{
 		validateCredentials(user);
 		validateBaseParameters(user);

--- a/cloudstack/java/jar/src/main/java/com/sixsq/slipstream/connector/cloudstack/CloudStackImageParametersFactory.java
+++ b/cloudstack/java/jar/src/main/java/com/sixsq/slipstream/connector/cloudstack/CloudStackImageParametersFactory.java
@@ -6,17 +6,14 @@ import com.sixsq.slipstream.persistence.ImageModule;
 
 public class CloudStackImageParametersFactory extends ModuleParametersFactoryBase {
 
-	public static final String SECURITY_GROUPS = "security.groups";
-
-	public CloudStackImageParametersFactory(String connectorInstanceName)
-			throws ValidationException {
+	public CloudStackImageParametersFactory(String connectorInstanceName) throws ValidationException {
 		super(connectorInstanceName);
 	}
 
 	@Override
 	protected void initReferenceParameters() throws ValidationException {
 		putParameter(ImageModule.INSTANCE_TYPE_KEY, "Instance type (flavor)", true);
-		putMandatoryParameter(SECURITY_GROUPS, "Security Groups (comma separated list)", "default");
+		addSecurityGroupsParameter();
 	}
 
 }

--- a/cloudstack/java/jar/src/main/java/com/sixsq/slipstream/connector/cloudstack/CloudStackSystemConfigurationParametersFactory.java
+++ b/cloudstack/java/jar/src/main/java/com/sixsq/slipstream/connector/cloudstack/CloudStackSystemConfigurationParametersFactory.java
@@ -3,11 +3,9 @@ package com.sixsq.slipstream.connector.cloudstack;
 import com.sixsq.slipstream.connector.SystemConfigurationParametersFactoryBase;
 import com.sixsq.slipstream.exceptions.ValidationException;
 
-public class CloudStackSystemConfigurationParametersFactory extends
-		SystemConfigurationParametersFactoryBase {	
+public class CloudStackSystemConfigurationParametersFactory extends SystemConfigurationParametersFactoryBase {
 	
-	public CloudStackSystemConfigurationParametersFactory(String connectorInstanceName)
-			throws ValidationException {
+	public CloudStackSystemConfigurationParametersFactory(String connectorInstanceName) throws ValidationException {
 		super(connectorInstanceName);
 	}
 
@@ -23,8 +21,9 @@ public class CloudStackSystemConfigurationParametersFactory extends
 		putMandatoryParameter(constructKey(CloudStackUserParametersFactory.ORCHESTRATOR_INSTANCE_TYPE_PARAMETER_NAME),
 				"Orchestrator instance type");
 		
-		putMandatoryParameter(constructKey(CloudStackUserParametersFactory.ZONE_PARAMETER_NAME), 
-				"Zone");
+		putMandatoryParameter(constructKey(CloudStackUserParametersFactory.ZONE_PARAMETER_NAME), "Zone");
+
+		putMandatoryOrchestratorSecurityGroups();
 
 		putMandatoryUpdateUrl();
 	}

--- a/cloudstack/python/tar/slipstream_cloudstack/LibcloudCloudstackPatch.py
+++ b/cloudstack/python/tar/slipstream_cloudstack/LibcloudCloudstackPatch.py
@@ -1,0 +1,128 @@
+"""
+ SlipStream Client
+ =====
+ Copyright (C) 2015 SixSq Sarl (sixsq.com)
+ =====
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from libcloud.compute.drivers.cloudstack import CloudStackNodeDriver
+from libcloud.compute.types import LibcloudError
+
+
+def ex_authorize_security_group_ingress(self, securitygroupname, protocol,
+                                        cidrlist, startport=None, endport=None,
+                                        icmptype=None, icmpcode=None, **kwargs):
+    """
+    Creates a new Security Group Ingress rule
+
+    :param   securitygroupname: The name of the security group.
+                                Mutually exclusive with securitygroupid.
+    :type    securitygroupname: ``str``
+
+    :param   protocol: Can be TCP, UDP or ICMP.
+                       Sometime other protocols can be used like AH, ESP, GRE.
+    :type    protocol: ``str``
+
+    :param   cidrlist: Source address CIDR for which this rule applies.
+    :type    cidrlist: ``str``
+
+    :param   startport: Start port of the range for this ingress rule.
+                        Applies to protocols TCP and UDP.
+    :type    startport: ``int``
+
+    :param   endport: End port of the range for this ingress rule.
+                      It can be None to set only one port.
+                      Applies to protocols TCP and UDP.
+    :type    endport: ``int``
+
+    :param   icmptype: Type of the ICMP packet (eg: 8 for Echo Request).
+                       -1 or None means "all types".
+                       Applies to protocol ICMP.
+    :type    icmptype: ``int``
+
+    :param   icmpcode: Code of the ICMP packet for the specified type.
+                       If the specified type doesn't require a code set this
+                       value to 0.
+                       -1 or None means "all codes".
+                       Applies to protocol ICMP.
+    :type    icmpcode: ``int``
+
+    :keyword   account: An optional account for the security group.
+                        Must be used with domainId.
+    :type      account: ``str``
+
+    :keyword domainid: An optional domainId for the security group.
+                       If the account parameter is used, domainId must also
+                       be used.
+
+    :keyword projectid: An optional project of the security group
+    :type    projectid: ``str``
+
+    :param securitygroupid: The ID of the security group.
+                            Mutually exclusive with securitygroupname
+    :type  securitygroupid: ``str``
+
+    :param usersecuritygrouplist: User to security group mapping
+    :type  usersecuritygrouplist: ``dict``
+
+    :rtype: ``dict``
+    """
+
+    args = kwargs.copy()
+    protocol = protocol.upper()
+
+    args.update({
+        'securitygroupname': securitygroupname,
+        'protocol': protocol,
+        'cidrlist': cidrlist
+    })
+
+    if protocol not in ('TCP', 'UDP') and \
+            (startport is not None or endport is not None):
+        raise LibcloudError('"startport" and "endport" are only valid with '
+                            'protocol TCP or UDP.')
+
+    if protocol != 'ICMP' and (icmptype is not None or icmpcode is not None):
+        raise LibcloudError('"icmptype" and "icmpcode" are only valid with '
+                            'protocol ICMP.')
+
+    if protocol in ('TCP', 'UDP'):
+        if startport is None:
+            raise LibcloudError('Protocols TCP and UDP require at least '
+                                '"startport" to be set.')
+        if startport is not None and endport is None:
+            endport = startport
+
+        args.update({
+            'startport': startport,
+            'endport': endport
+        })
+
+    if protocol == 'ICMP':
+        if icmptype is None:
+            icmptype = -1
+        if icmpcode is None:
+            icmpcode = -1
+
+        args.update({
+            'icmptype': icmptype,
+            'icmpcode': icmpcode
+        })
+
+    return self._async_request(command='authorizeSecurityGroupIngress',
+                               params=args,
+                               method='GET')['securitygroup']
+
+def patch_libcloud():
+    CloudStackNodeDriver.ex_authorize_security_group_ingress = ex_authorize_security_group_ingress

--- a/openstack/java/jar/src/main/java/com/sixsq/slipstream/connector/openstack/OpenStackConnector.java
+++ b/openstack/java/jar/src/main/java/com/sixsq/slipstream/connector/openstack/OpenStackConnector.java
@@ -80,9 +80,9 @@ public class OpenStackConnector extends CliConnectorBase {
 			throws ConfigurationException, ValidationException {
 		Map<String, String> launchParams = new HashMap<String, String>();
 		launchParams.put("instance-type", getInstanceType(run));
-		launchParams.put("security-groups", getSecurityGroups(run));
         launchParams.put("network-public", getNetworkPublic());
         launchParams.put("network-private", getNetworkPrivate());
+		putLaunchParamSecurityGroups(launchParams, run, user);
 		return launchParams;
 	}
 
@@ -111,11 +111,6 @@ public class OpenStackConnector extends CliConnectorBase {
 		return (isInOrchestrationContext(run)) ? Configuration.getInstance()
 				.getRequiredProperty(constructKey(OpenStackUserParametersFactory.ORCHESTRATOR_INSTANCE_TYPE_PARAMETER_NAME))
 				: getInstanceType(ImageModule.load(run.getModuleResourceUrl()));
-	}
-
-	protected String getSecurityGroups(Run run) throws ValidationException{
-		return (isInOrchestrationContext(run)) ? "default"
-				: getParameterValue(OpenStackImageParametersFactory.SECURITY_GROUPS, ImageModule.load(run.getModuleResourceUrl()));
 	}
 
 	protected String getProject(User user) throws ValidationException {

--- a/openstack/java/jar/src/main/java/com/sixsq/slipstream/connector/openstack/OpenStackImageParametersFactory.java
+++ b/openstack/java/jar/src/main/java/com/sixsq/slipstream/connector/openstack/OpenStackImageParametersFactory.java
@@ -26,8 +26,6 @@ import com.sixsq.slipstream.persistence.ImageModule;
 
 public class OpenStackImageParametersFactory extends ModuleParametersFactoryBase {
 
-	public static final String SECURITY_GROUPS = "security.groups";
-
 	public OpenStackImageParametersFactory(String connectorInstanceName) throws ValidationException {
 		super(connectorInstanceName);
 	}
@@ -35,6 +33,6 @@ public class OpenStackImageParametersFactory extends ModuleParametersFactoryBase
 	@Override
 	protected void initReferenceParameters() throws ValidationException {
 		putParameter(ImageModule.INSTANCE_TYPE_KEY, "Instance type (flavor)", true);
-		putMandatoryParameter(SECURITY_GROUPS, "Security Groups (comma separated list)", "default");
+		addSecurityGroupsParameter();
 	}
 }

--- a/openstack/java/jar/src/main/java/com/sixsq/slipstream/connector/openstack/OpenStackSystemConfigurationParametersFactory.java
+++ b/openstack/java/jar/src/main/java/com/sixsq/slipstream/connector/openstack/OpenStackSystemConfigurationParametersFactory.java
@@ -23,11 +23,9 @@ package com.sixsq.slipstream.connector.openstack;
 import com.sixsq.slipstream.connector.SystemConfigurationParametersFactoryBase;
 import com.sixsq.slipstream.exceptions.ValidationException;
 
-public class OpenStackSystemConfigurationParametersFactory extends
-		SystemConfigurationParametersFactoryBase {
+public class OpenStackSystemConfigurationParametersFactory extends SystemConfigurationParametersFactoryBase {
 
-	public OpenStackSystemConfigurationParametersFactory(String connectorInstanceName)
-			throws ValidationException {
+	public OpenStackSystemConfigurationParametersFactory(String connectorInstanceName) throws ValidationException {
 		super(connectorInstanceName);
 	}
 
@@ -59,6 +57,8 @@ public class OpenStackSystemConfigurationParametersFactory extends
 
         putMandatoryParameter(constructKey(OpenStackUserParametersFactory.NETWORK_PRIVATE_NAME),
                 "Mapping for Private network", "");
+
+		putMandatoryOrchestratorSecurityGroups();
 
 		putMandatoryUpdateUrl();
 


### PR DESCRIPTION
Automatically create a security group with everything allowed.

Connected to slipstream/SlipStreamClient#140

Require:
- slipstream/SlipStreamServer#470
- slipstream/SlipStreamClient#173