### PR TITLE
OpenStack: don't initialise IaaS attributes unless run or build image

### DIFF
--- a/openstack/python/tar/bin/openstack-describe-instances
+++ b/openstack/python/tar/bin/openstack-describe-instances
@@ -23,7 +23,6 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 from slipstream.command.CloudClientCommand import main
 from slipstream.command.DescribeInstancesCommand import DescribeInstancesCommand
 from slipstream_openstack.OpenStackCommand import OpenStackCommand
-from slipstream_openstack.OpenStackClientCloud import OpenStackClientCloud
 
 
 class OpenStackDescribeInstances(DescribeInstancesCommand, OpenStackCommand):

--- a/openstack/python/tar/slipstream_openstack/OpenStackClientCloud.py
+++ b/openstack/python/tar/slipstream_openstack/OpenStackClientCloud.py
@@ -71,14 +71,12 @@ class OpenStackClientCloud(BaseCloudConnector):
     def _initialization(self, user_info):
         util.printStep('Initialize the OpenStack connector.')
         self._thread_local.driver = self._get_driver(user_info)
-        self.flavors = self._thread_local.driver.list_sizes()
-        self.images = self._thread_local.driver.list_images()
-        self.networks = self._thread_local.driver.ex_list_networks()
-        self.security_groups = self._thread_local.driver.ex_list_security_groups()
 
         if self.is_deployment():
+            self._get_iaas_attributes()
             self._import_keypair(user_info)
         elif self.is_build_image():
+            self._get_iaas_attributes()
             self._create_keypair_and_set_on_user_info(user_info)
 
     @override
@@ -89,6 +87,12 @@ class OpenStackClientCloud(BaseCloudConnector):
         # pylint: disable=W0703
         except Exception:
             pass
+
+    def _get_iaas_attributes(self):
+        self.flavors = self._thread_local.driver.list_sizes()
+        self.images = self._thread_local.driver.list_images()
+        self.networks = self._thread_local.driver.ex_list_networks()
+        self.security_groups = self._thread_local.driver.ex_list_security_groups()
 
     def _build_image(self, user_info, node_instance):
         return self._build_image_on_openstack(user_info, node_instance)

--- a/openstack/python/tar/slipstream_openstack/OpenStackClientCloud.py
+++ b/openstack/python/tar/slipstream_openstack/OpenStackClientCloud.py
@@ -71,6 +71,7 @@ class OpenStackClientCloud(BaseCloudConnector):
     def _initialization(self, user_info):
         util.printStep('Initialize the OpenStack connector.')
         self._thread_local.driver = self._get_driver(user_info)
+        self.flavors = self._thread_local.driver.list_sizes()
 
         if self.is_deployment():
             self._get_iaas_attributes()
@@ -89,7 +90,6 @@ class OpenStackClientCloud(BaseCloudConnector):
             pass
 
     def _get_iaas_attributes(self):
-        self.flavors = self._thread_local.driver.list_sizes()
         self.images = self._thread_local.driver.list_images()
         self.networks = self._thread_local.driver.ex_list_networks()
         self.security_groups = self._thread_local.driver.ex_list_security_groups()

--- a/openstack/python/tar/test/TestOpenStackClientCloudLive.py
+++ b/openstack/python/tar/test/TestOpenStackClientCloudLive.py
@@ -164,6 +164,10 @@ lvs
         new_id = self.client.build_image(self.user_info, self.node_instance)
         assert new_id
 
+    def xtest_3_list_instances(self):
+        self.client._initialization(self.user_info)
+        assert isinstance(self.client.list_instances(), list)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Connected to #77 