### PR TITLE
fix for SL connector build image

### DIFF
--- a/stratuslab/python/tar/slipstream_stratuslab/StratusLabClientCloud.py
+++ b/stratuslab/python/tar/slipstream_stratuslab/StratusLabClientCloud.py
@@ -162,6 +162,12 @@ class StratusLabClientCloud(BaseCloudConnector):
     @override
     def _build_image(self, user_info, node_instance):
 
+        machine_name = node_instance.get_name()
+        vm = self._get_vm(machine_name)
+        vm_ip = self._vm_get_ip(vm)
+
+        self._build_image_increment(user_info, node_instance, vm_ip)
+
         self.creator.createStep2()
 
         image_id = self._search_storage_for_new_image(self.slConfigHolder)

--- a/stratuslab/python/tar/slipstream_stratuslab/stratuslabPatch.py
+++ b/stratuslab/python/tar/slipstream_stratuslab/stratuslabPatch.py
@@ -31,8 +31,6 @@ def createStep1(self):
 
 
 def createStep2(self):
-    self._checkIfCanConnectToMachine()
-    self.buildNodeIncrement()
     self._shutdownNode()
     self._printAction('Finished building image increment.')
     self._printAction('Please check %s for new image ID and instruction.' % \

--- a/stratuslab/python/tar/test/TestStratusLabClientCloudLive.py
+++ b/stratuslab/python/tar/test/TestStratusLabClientCloudLive.py
@@ -38,7 +38,7 @@ class TestStratusLabClientCloudLive(TestStratusLabLiveBase):
     def xtest_3_build_image(self):
 
         with open(os.path.expanduser('~/.ssh/id_rsa')) as fd:
-            self.user_info['stratusla.private.key'] = fd.read()
+            self.user_info['stratuslab.private.key'] = fd.read()
 
         self.client.run_category = RUN_CATEGORY_IMAGE
         self.client._prepare_machine_for_build_image = Mock()

--- a/stratuslab/python/tar/test/TestStratusLabClientCloudLive.py
+++ b/stratuslab/python/tar/test/TestStratusLabClientCloudLive.py
@@ -17,6 +17,7 @@
  limitations under the License.
 """
 
+import os
 import unittest
 from mock import Mock
 
@@ -35,6 +36,9 @@ class TestStratusLabClientCloudLive(TestStratusLabLiveBase):
         self._start_stop_instances_by_ids()
 
     def xtest_3_build_image(self):
+
+        with open(os.path.expanduser('~/.ssh/id_rsa')) as fd:
+            self.user_info['stratusla.private.key'] = fd.read()
 
         self.client.run_category = RUN_CATEGORY_IMAGE
         self.client._prepare_machine_for_build_image = Mock()

--- a/stratuslab/python/tar/test/TestStratusLabLiveBase.py
+++ b/stratuslab/python/tar/test/TestStratusLabLiveBase.py
@@ -109,23 +109,33 @@ class TestStratusLabLiveBase(unittest.TestCase):
             'stratuslab.cpu': '',
             'stratuslab.ram': '',
             'network': 'public',
-            'image.prerecipe':
+            'image.prerecipe': [
+                {"name": "prerecipe",
+                 "order": 1,
+                 "module": "component",
+                 "module_uri": "path/to/component",
+                 "script":
 """#!/bin/sh
 set -e
 set -x
 
 ls -l /tmp
 dpkg -l | egrep "nano|lvm" || true
-""",
+"""}],
             'image.packages' : ['lvm2', 'nano'],
-            'image.recipe':
+            'image.recipe': [
+                {"name": "prerecipe",
+                 "order": 1,
+                 "module": "component",
+                 "module_uri": "path/to/component",
+                "script":
 """#!/bin/sh
 set -e
 set -x
 
 dpkg -l | egrep "nano|lvm" || true
 lvs
-"""
+"""}]
         })
 
     def tearDown(self):


### PR DESCRIPTION
- transfer the execution of the build image action from SL Creator to the one done by SlipStream.

Connected to #116 