### PR TITLE
fix ssh private key management for build image on SL connector

### DIFF
--- a/stratuslab/python/tar/slipstream_stratuslab/StratusLabClientCloud.py
+++ b/stratuslab/python/tar/slipstream_stratuslab/StratusLabClientCloud.py
@@ -108,7 +108,7 @@ class StratusLabClientCloud(BaseCloudConnector):
 
     def _start_image_for_build(self, user_info, node_instance):
 
-        self._prepare_machine_for_build_image()
+        self._prepare_machine_for_build_image(user_info)
 
         manifest_downloader = ManifestDownloader(self.slConfigHolder)
 
@@ -377,8 +377,10 @@ class StratusLabClientCloud(BaseCloudConnector):
     def _get_stratuslab_runner(image_id, slConfigHolder):
         return Runner(image_id, slConfigHolder)
 
-    def _prepare_machine_for_build_image(self):
+    def _prepare_machine_for_build_image(self, user_info):
         generate_ssh_keypair(self.sshPrivKeyFile)
+        user_info.set_private_key(open(self.sshPrivKeyFile).read())
+
         self._install_packages_local(['curl'])
 
     @staticmethod


### PR DESCRIPTION
The patch is already on nuv.la and was tested with this run https://nuv.la/run/195fb9ba-21ef-4541-a551-f9ae0f5a4547

Connected to #116 